### PR TITLE
bugfix and AreCollectionNotEmpty

### DIFF
--- a/OpenSubsystemsLibrary/src/CommonModules/Assert/Module.bsl
+++ b/OpenSubsystemsLibrary/src/CommonModules/Assert/Module.bsl
@@ -84,9 +84,20 @@ EndProcedure
 
 Procedure AreCollectionEmpty(Value, Message = "") Export
     
+    If Value.Count() <> 0 Then 
+        Raise AssertError(
+            NStr("ru = 'Не пустая коллекция.'; en = 'Collection isn't empty.'"),
+            Value,
+            Message);
+    EndIf;
+    
+EndProcedure
+
+Procedure AreCollectionNotEmpty(Value, Message = "") Export
+    
     If Value.Count() = 0 Then 
         Raise AssertError(
-            NStr("ru = 'Пустая коллекция.'; en = 'Empty collection.'"),
+            NStr("ru = 'Пустая коллекция.'; en = 'Collection is empty.'"),
             Value,
             Message);
     EndIf;


### PR DESCRIPTION
### Changes

- bugfix AreCollectionEmpty
- add AreCollectionNotEmpty

### Methodic checks

- [x] Multiple time zones was checked.
- [x] Data updates do not spoil data.
- [x] Each borrowed code was checked for compliance with the license of this library and added to [LICENSE.NOTICE](../../LICENSE.NOTICE).

### Manual codebase checks

- [x] 4 spaces per indentation level.
- [x] Messages and synonyms have English and Russian localization.
- [ ] Methods descriptions of public interface.
- [x] Code comments are clear and don't have mistakes.
- [x] Variable naming convention is not broken.
- [ ] Form modules don't contain public interface.
- [ ] Command modules don't have export methods.
- [ ] `Modify Data` property setted for commands that changes the data.
- [ ] Metadata standard attributes names for `Parent` and `Owner` have synonyms.
- [ ] Roles rights don't contain dangerous actions.

### User mode checks

- [x] Interface style guide is fully compatible to [#std (RU)](https://its.1c.ru/db/v8std#browse:13:-1:7).
