### PR TITLE
feat: Aded Tuple and Detuple global methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.metadata/
+/build/

--- a/OpenSubsystemsLibrary.Tests/src/CommonModules/Test_Tuple/Module.bsl
+++ b/OpenSubsystemsLibrary.Tests/src/CommonModules/Test_Tuple/Module.bsl
@@ -1,0 +1,42 @@
+// BSLLS:UsingServiceTag-off
+// BSLLS:MissingParameterDescription-off
+// BSLLS:CodeOutOfRegion-off
+
+// @unit-test
+Procedure Test_Tuple(Context) Export
+    
+    Result = Tuple(0, "Val1");
+    
+    Assert.AreEqual(Type("FixedArray"), TypeOf(Result));
+
+    Assert.AreCollectionNotEmpty(Result);
+
+    Assert.AreEqual(0, Result[0], 0);
+    Assert.AreEqual("Val1", Result[1]);
+    
+EndProcedure
+
+// @unit-test
+Procedure Test_Detuple(Context) Export
+    
+    Result = Tuple(0, "Val1");
+    
+    Res = Detuple(Result);
+    
+    Assert.AreEqual(Type("FixedStructure"), TypeOf(Res));
+
+    Assert.AreCollectionNotEmpty(Result);
+    
+    Assert.AreEqual(0, Res.Item1);
+    Assert.AreEqual("Val1", Res.Item2);
+
+    Res = Detuple(Result, "Value1", "Value2");
+    
+    Assert.AreEqual(Type("FixedStructure"), TypeOf(Res));
+
+    Assert.AreCollectionNotEmpty(Result); 
+    
+    Assert.AreEqual(0, Res.Value1);
+    Assert.AreEqual("Val1", Res.Value2);
+    
+EndProcedure

--- a/OpenSubsystemsLibrary.Tests/src/CommonModules/Test_Tuple/Test_Tuple.mdo
+++ b/OpenSubsystemsLibrary.Tests/src/CommonModules/Test_Tuple/Test_Tuple.mdo
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdclass:CommonModule xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="7f1a2b6f-b0dd-4e1e-a188-98874ea76190">
+  <name>Test_Tuple</name>
+  <synonym>
+    <key>en</key>
+    <value>Tuple</value>
+  </synonym>
+  <server>true</server>
+</mdclass:CommonModule>

--- a/OpenSubsystemsLibrary.Tests/src/Configuration/Configuration.mdo
+++ b/OpenSubsystemsLibrary.Tests/src/Configuration/Configuration.mdo
@@ -51,6 +51,7 @@
   <commonModules>CommonModule.Test_Reflection</commonModules>
   <commonModules>CommonModule.Test_Reflection_MockModule</commonModules>
   <commonModules>CommonModule.Test_Reflection_MockModuleClient</commonModules>
+  <commonModules>CommonModule.Test_Tuple</commonModules>
   <commonForms>CommonForm.Test_Diagnostic</commonForms>
   <catalogs>Catalog.Users</catalogs>
   <dataProcessors>DataProcessor.Test_BackgroundWorker</dataProcessors>

--- a/OpenSubsystemsLibrary/src/CommonModules/Collections/Collections.mdo
+++ b/OpenSubsystemsLibrary/src/CommonModules/Collections/Collections.mdo
@@ -5,5 +5,6 @@
     <key>en</key>
     <value>Collections</value>
   </synonym>
+  <clientManagedApplication>true</clientManagedApplication>
   <server>true</server>
 </mdclass:CommonModule>

--- a/OpenSubsystemsLibrary/src/CommonModules/Collections/Module.bsl
+++ b/OpenSubsystemsLibrary/src/CommonModules/Collections/Module.bsl
@@ -38,4 +38,18 @@ Function IsDictionary(Self) Export
     
 EndFunction
 
+// Adding non Null value to collection
+// 
+// Parameters:
+//  Self - Array, FixedArray - collection
+//  Value - Any - value to add
+//
+Procedure AddNonNullValue(Self, Value) Export
+
+    If Value <> Null Then
+        Self.Add(Value);
+    EndIf;
+
+EndProcedure
+
 #EndRegion

--- a/OpenSubsystemsLibrary/src/CommonModules/TupleGlobal/Module.bsl
+++ b/OpenSubsystemsLibrary/src/CommonModules/TupleGlobal/Module.bsl
@@ -1,0 +1,89 @@
+#Region Public
+
+// Create tuple of given items
+// 
+// Parameters:
+//  Item1 - Any
+//  Item2 - Any
+//  Item3 - Any
+//  Item4 - Any
+//  Item5 - Any
+//  Item6 - Any
+//  Item7 - Any
+//  Item8 - Any
+//  Item9 - Any
+//  Item10 - Any
+// 
+// Returns:
+//  FixedArray - Tuple
+// 
+// Example:
+//  Tuple = Tuple(0, "Val");
+//  // Tuple[0]  0
+//  // Tuple[1]  "Val"
+//
+Function Tuple(Item1, Item2, Item3 = Null, Item4 = Null, Item5 = Null,
+    Item6 = Null, Item7 = Null, Item8 = Null, Item9 = Null, Item10 = Null) Export
+    
+    Result = New Array();
+    
+    For index = 1 To 10 Do
+        
+        Collections.AddNonNullValue(Result, Eval(StrTemplate("item%1", index)));
+        
+    EndDo;
+    
+    Return New FixedArray(Result);
+    
+EndFunction
+
+// Detuple given tuple
+// 
+// Parameters:
+//  Tuple - see TupleGlobal.Tuple - Tuple
+//  Item1 - String - Name of 1 value of tuple
+//  Item2 - String - Name of 2 value of tuple
+//  Itme3 - String - Name of 3 value of tuple
+//  Item4 - String - Name of 4 value of tuple
+//  Item5 - String - Name of 5 value of tuple
+//  Item6 - String - Name of 6 value of tuple
+//  Item7 - String - Name of 7 value of tuple
+//  Item8 - String - Name of 8 value of tuple
+//  Item9 - String - Name of 9 value of tuple
+//  Item10 - String - Name of 10 value of tuple
+// 
+// Returns:
+//  FixedStructure - Detupled tuple
+//
+// Example:
+//  Tuple = Tuple(0, "val");
+//  Result = Detuple(Tuple);
+//  // Result.Item1  0
+//  // Result.Item2  "val"
+//  
+//  Result = Detuple(Tuple, "Key", "Value")
+//  // Result.Key    0
+//  // Result.Value  "val"
+//
+Function Detuple(Tuple, Item1 = "", Item2 = "", Itme3 = "", Item4 = "",
+    Item5 = "", Item6 = "", Item7 = "", Item8 = "", Item9 = "", Item10 = "") Export
+    
+    Result = New Structure();
+    
+    For index = 0 To Tuple.UBound() Do
+
+        ItemName = StrTemplate("Item%1", index + 1);
+        AssignedItemName = Eval(ItemName);
+
+        Result.Insert(
+            ?(IsBlankString(AssignedItemName), ItemName, AssignedItemName),
+            Tuple[index]
+        );
+        
+    EndDo;
+    
+    Return New FixedStructure(Result);
+    
+EndFunction
+
+#EndRegion

--- a/OpenSubsystemsLibrary/src/CommonModules/TupleGlobal/TupleGlobal.mdo
+++ b/OpenSubsystemsLibrary/src/CommonModules/TupleGlobal/TupleGlobal.mdo
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdclass:CommonModule xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="aad15720-558c-4dca-8d03-4f4d152a9db7">
+  <name>TupleGlobal</name>
+  <global>true</global>
+  <clientManagedApplication>true</clientManagedApplication>
+  <server>true</server>
+</mdclass:CommonModule>

--- a/OpenSubsystemsLibrary/src/Configuration/Configuration.mdo
+++ b/OpenSubsystemsLibrary/src/Configuration/Configuration.mdo
@@ -96,6 +96,7 @@
   <commonModules>CommonModule.Strings</commonModules>
   <commonModules>CommonModule.SystemImplClient</commonModules>
   <commonModules>CommonModule.SystemImplServerCall</commonModules>
+  <commonModules>CommonModule.TupleGlobal</commonModules>
   <commonModules>CommonModule.Users</commonModules>
   <scheduledJobs>ScheduledJob.MergePartialFullTextSearchIndex</scheduledJobs>
   <scheduledJobs>ScheduledJob.UpdateDataHistory</scheduledJobs>


### PR DESCRIPTION
Closes: #22 

### Changes

Aded Tuple and Detuple global methods

### Methodic checks

- [x] Multiple time zones was checked.
- [x] Data updates do not spoil data.
- [x] Each borrowed code was checked for compliance with the license of this library and added to [LICENSE.NOTICE](../../LICENSE.NOTICE).

### Manual codebase checks

- [x] 4 spaces per indentation level.
- [x] Messages and synonyms have English and Russian localization.
- [x] Methods descriptions of public interface.
- [x] Code comments are clear and don't have mistakes.
- [x] Variable naming convention is not broken.
- [x] Form modules don't contain public interface.
- [x] Command modules don't have export methods.
- [x] `Modify Data` property setted for commands that changes the data.
- [x] Metadata standard attributes names for `Parent` and `Owner` have synonyms.
- [x] Roles rights don't contain dangerous actions.

### User mode checks

- [x] Interface style guide is fully compatible to [#std (RU)](https://its.1c.ru/db/v8std#browse:13:-1:7).
